### PR TITLE
Add version checking and force upgrade functionality to upgrade.sh

### DIFF
--- a/scripts/_bouncer.sh
+++ b/scripts/_bouncer.sh
@@ -204,6 +204,88 @@ delete_bouncer() {
     fi
 }
 
+# Extract version from bouncer binary output
+get_bouncer_version() {
+    local bouncer_bin version_output
+    bouncer_bin="$1"
+    
+    if [ ! -f "$bouncer_bin" ]; then
+        echo "0.0.0"
+        return 1
+    fi
+    
+    version_output=$("$bouncer_bin" --version 2>&1 || echo "")
+    if [ "$version_output" = "" ]; then
+        echo "0.0.0"
+        return 1
+    fi
+    
+    # Extract version from output like "version: v1.2.3-abc123..."
+    echo "$version_output" | grep -Eio 'v[0-9]+.[0-9]+.[0-9]+' | cut -c 2- || echo "0.0.0"
+}
+
+# Compare two version strings (returns 0 if v1 >= v2, 1 otherwise)
+version_compare() {
+    local v1 v2
+    v1="$1"
+    v2="$2"
+    
+    # Split versions into major.minor.patch
+    local v1_major v1_minor v1_patch v2_major v2_minor v2_patch
+    
+    v1_major=$(echo "$v1" | cut -d'.' -f1)
+    v1_minor=$(echo "$v1" | cut -d'.' -f2)
+    v1_patch=$(echo "$v1" | cut -d'.' -f3)
+    
+    v2_major=$(echo "$v2" | cut -d'.' -f1)
+    v2_minor=$(echo "$v2" | cut -d'.' -f2)
+    v2_patch=$(echo "$v2" | cut -d'.' -f3)
+    
+    # Compare major version
+    if [ "$v1_major" -gt "$v2_major" ]; then
+        return 0
+    elif [ "$v1_major" -lt "$v2_major" ]; then
+        return 1
+    fi
+    
+    # Compare minor version
+    if [ "$v1_minor" -gt "$v2_minor" ]; then
+        return 0
+    elif [ "$v1_minor" -lt "$v2_minor" ]; then
+        return 1
+    fi
+    
+    # Compare patch version
+    if [ "$v1_patch" -ge "$v2_patch" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Check if upgrade is needed by comparing versions
+check_upgrade_needed() {
+    local current_version new_version
+    current_version=$(get_bouncer_version "$BIN_PATH_INSTALLED")
+    new_version=$(get_bouncer_version "$BIN_PATH")
+    
+    msg info "Current version: $current_version"
+    msg info "New version: $new_version"
+    
+    if version_compare "$new_version" "$current_version"; then
+        if [ "$new_version" = "$current_version" ]; then
+            msg info "Versions are the same, no upgrade needed"
+            return 1
+        else
+            msg info "Upgrade available: $current_version -> $new_version"
+            return 0
+        fi
+    else
+        msg warn "New version ($new_version) is older than current version ($current_version)"
+        return 1
+    fi
+}
+
 upgrade_bin() {
     require 'BIN_PATH' 'BIN_PATH_INSTALLED'
     rm "$BIN_PATH_INSTALLED"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -4,9 +4,63 @@ set -eu
 
 . ./scripts/_bouncer.sh
 
+# Parse command line arguments
+FORCE_UPGRADE=false
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --force|-f)
+            FORCE_UPGRADE=true
+            shift
+            ;;
+        --help|-h)
+            echo "Usage: $0 [--force|-f] [--help|-h]"
+            echo "  --force, -f    Force upgrade even if versions are the same"
+            echo "  --help, -h     Show this help message"
+            exit 0
+            ;;
+        *)
+            msg err "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
 assert_root
 
 # --------------------------------- #
+
+# Check if upgrade is needed (unless forced)
+if [ "$FORCE_UPGRADE" = "false" ]; then
+    if ! check_upgrade_needed; then
+        msg info "No upgrade needed or upgrade not recommended"
+        msg info "Use --force to override this check"
+        exit 0
+    fi
+else
+    msg info "Force upgrade enabled, skipping version check"
+    # Still show version info for user awareness
+    current_version=$(get_bouncer_version "$BIN_PATH_INSTALLED")
+    new_version=$(get_bouncer_version "$BIN_PATH")
+    msg info "Current version: $current_version"
+    msg info "New version: $new_version"
+fi
+
+# Ask for confirmation if running interactively
+if [ -t 0 ]; then
+    echo
+    msg info "Do you want to proceed with the upgrade? (y/N)"
+    read -r response
+    case "$response" in
+        [yY]|[yY][eE][sS])
+            msg info "Proceeding with upgrade..."
+            ;;
+        *)
+            msg info "Upgrade cancelled by user"
+            exit 0
+            ;;
+    esac
+fi
 
 systemctl stop "$SERVICE"
 


### PR DESCRIPTION
fix #77

Features added:
    - Version comparison between current and new binaries
    - Smart upgrade detection (skips if versions are same or new version is older)
    - Force upgrade option (--force/-f) to override version checks
    - Help option (--help/-h) with usage information
    - User confirmation prompt for interactive upgrades
    - Informative messages about version differences

This addresses user requests for:
    - Checking if upgrade is actually needed before proceeding
    - Ability to force upgrade when building from source
    - Better user experience with clear feedback about version changes

Functions added to _bouncer.sh:
    - get_bouncer_version(): Extract version from binary --version output
    - version_compare(): Compare semantic versions (major.minor.patch)
    - check_upgrade_needed(): Main logic for upgrade decision making
