### PR TITLE
Add debug logging when no host matches in MatchFirstHost

### DIFF
--- a/pkg/host/root.go
+++ b/pkg/host/root.go
@@ -90,6 +90,7 @@ func (h *Manager) MatchFirstHost(toMatch string) *Host {
 			return host
 		}
 	}
+	h.Logger.WithField("requested_host", toMatch).Debug("no matching host found")
 	return nil
 }
 


### PR DESCRIPTION
To aid user debugging issues when host is not matching any current defined hosts.