### PR TITLE
Optimize MatchFirstHost with early return when no hosts configured

### DIFF
--- a/pkg/host/root.go
+++ b/pkg/host/root.go
@@ -77,6 +77,10 @@ func (h *Manager) MatchFirstHost(toMatch string) *Host {
 	h.RLock()
 	defer h.RUnlock()
 
+	if len(h.Hosts) == 0 {
+		return nil
+	}
+
 	if host, ok := h.cache[toMatch]; ok {
 		host.logger.WithField("requested_host", toMatch).Debug("matched host from cache")
 		return host


### PR DESCRIPTION
### Summary
Optimize `MatchFirstHost` function by adding early return when no hosts are configured.

### Changes
- Added `len(h.Hosts) == 0` check at the beginning of `MatchFirstHost` (line 80-82)
- Returns `nil` immediately if no hosts are configured, avoiding unnecessary cache lookups

### Performance Impact
- **Before**: Function would check cache and iterate through empty host list
- **After**: Returns immediately when no hosts configured, skipping all lookup logic

### Benefits
1. **Performance**: Eliminates unnecessary operations when no hosts are configured
2. **Clarity**: Makes it explicit that matching requires hosts to be configured
3. **Efficiency**: Avoids cache access and loop iteration on empty host list

### Testing
- No functional changes to behavior
- Maintains same return value (`nil`) when no hosts match
- No impact when hosts are configured