### PR TITLE
Add IP remediation fallback when remediation variable not set

### DIFF
--- a/config/crowdsec.cfg
+++ b/config/crowdsec.cfg
@@ -12,8 +12,9 @@ spoe-agent crowdsec-agent
     log         global
 
 ## This message is used to customise the remediation from crowdsec-ip based on the host header
+## src-ip is included as fallback in case crowdsec-ip message didn't fire
 spoe-message crowdsec-http
-    args remediation=var(txn.crowdsec.remediation) crowdsec_captcha_cookie=req.cook(crowdsec_captcha_cookie) id=unique-id host=hdr(Host) method=method path=path query=query version=req.ver headers=req.hdrs body=req.body url=url ssl=ssl_fc
+    args remediation=var(txn.crowdsec.remediation) crowdsec_captcha_cookie=req.cook(crowdsec_captcha_cookie) id=unique-id host=hdr(Host) method=method path=path query=query version=req.ver headers=req.hdrs body=req.body url=url ssl=ssl_fc src-ip=src src-port=src_port
     event on-frontend-http-request
 
 ## This message should be the first to trigger in the chain


### PR DESCRIPTION
before #85 

When HAProxy is behind an upstream proxy and only fires on-frontend-http-request, the crowdsec-ip message may not set the remediation variable. This adds fallback logic to check IP remediation directly in handleHTTPRequest when needed.

Changes:
- Extract IP checking logic into shared getIPRemediation() function (DRY)
- Add checkIPRemediation() fallback in handleHTTPRequest
- Include src-ip in crowdsec-http message args for fallback scenario
- Refactor handleIPRequest to use shared getIPRemediation() function

This enables configurations where crowdsec-http can work standalone with req.hdr_ip() to extract real client IP from proxy headers as shown in #85.

**tldr** when firing on `on-http-request` we cannot guarantee ordering, we must do the same logic in one function if the remediation variable is not sent.