### PR TITLE
fix: Debian and RPM packaging to properly install files

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -16,11 +16,11 @@ override_dh_auto_install:
 
 	@BOUNCER=crowdsec-spoa-bouncer; \
 	PKG="crowdsec-haproxy-spoa-bouncer"; \
-	install -D "$$BOUNCER" -t "debian/$$PKG/usr/bin/"; \
-	install -D "scripts/_bouncer.sh" -t "debian/$$PKG/usr/lib/$$PKG/"; \
-	install -D "config/$$BOUNCER.yaml" "debian/$$PKG/etc/crowdsec/bouncers/$$BOUNCER.yaml"; \
+	install -m 755 -D "$$BOUNCER" "debian/$$PKG/usr/bin/$$BOUNCER"; \
+	install -m 600 -D "scripts/_bouncer.sh" "debian/$$PKG/usr/lib/$$PKG/_bouncer.sh"; \
+	install -m 640 -D "config/$$BOUNCER.yaml" "debian/$$PKG/etc/crowdsec/bouncers/$$BOUNCER.yaml"; \
 	mkdir -p "debian/$$PKG/lib/systemd/system"; \
-	BIN="/usr/bin/$$BOUNCER" CFG="/etc/crowdsec/bouncers" envsubst '$$BIN $$CFG' < "config/$$BOUNCER.service" > "debian/$$PKG/lib/systemd/system/$$BOUNCER.service"
+	BIN="/usr/bin/$$BOUNCER" CFG="/etc/crowdsec/bouncers" envsubst '$$BIN $$CFG' < "config/$$BOUNCER.service" > "debian/$$PKG/lib/systemd/system/$$BOUNCER.service"; \
 	mkdir -p "debian/$$PKG/usr/lib/$$PKG/lua"; \
 	mkdir -p "debian/$$PKG/usr/share/doc/$$PKG/examples"; \
 	install -m 644 -D "config/crowdsec.cfg" "debian/$$PKG/usr/share/doc/$$PKG/examples/crowdsec.cfg"; \
@@ -30,12 +30,9 @@ override_dh_auto_install:
 	install -m 644 -D "lua/template.lua" "debian/$$PKG/usr/lib/$$PKG/lua/template.lua"; \
 	mkdir -p "debian/$$PKG/var/lib/$$PKG/html"; \
 	install -m 644 -D "templates/ban.html" "debian/$$PKG/var/lib/$$PKG/html/ban.html"; \
-	install -m 644 -D "templates/captcha.html" "debian/$$PKG/var/lib/$$PKG/html/captcha.html"; \
+	install -m 644 -D "templates/captcha.html" "debian/$$PKG/var/lib/$$PKG/html/captcha.html"
 
 execute_after_dh_fixperms:
 	@BOUNCER=crowdsec-spoa-bouncer; \
 	PKG="crowdsec-haproxy-spoa-bouncer"; \
-	chmod 0755 "debian/$$PKG/usr/bin/$$BOUNCER"; \
-	chmod 0600 "debian/$$PKG/usr/lib/$$PKG/_bouncer.sh"; \
-	chmod 0640 "debian/$$PKG/etc/crowdsec/bouncers/$$BOUNCER.yaml"; \
 	chmod 0644 "debian/$$PKG/lib/systemd/system/$$BOUNCER.service"


### PR DESCRIPTION
- Fix debian/rules: Replace incorrect 'install -D ... -t' syntax with full
  destination paths. The -D flag requires a full destination path, not a
  target directory with -t flag.

- Fix rpm spec: Correct examples directory path from %{_docdir}/examples to
  %{_docdir}/%{name}/examples to match actual installation paths. Add explicit
  lua directory creation and consistent file permissions.

These fixes ensure that Lua files, example configs, and template files are
properly installed in both Debian and RPM packages.- Fix debian/rules: Replace incorrect 'install -D ... -t' syntax with full
  destination paths. The -D flag requires a full destination path, not a
  target directory with -t flag.

- Fix rpm spec: Correct examples directory path from %{_docdir}/examples to
  %{_docdir}/%{name}/examples to match actual installation paths. Add explicit
  lua directory creation and consistent file permissions.

These fixes ensure that Lua files, example configs, and template files are
properly installed in both Debian and RPM packages.