### PR TITLE
chore: add .vagrant/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ venv/
 
 # local configuration
 /config/*.yaml.local
+
+# Vagrant
+.vagrant/


### PR DESCRIPTION
- Add .vagrant/ directory to .gitignore to prevent accidental commits
- Vagrant state files should not be tracked in version control