### PR TITLE
chore: Upgrade haproxy-spoe-go to v1.0.7 and remove manual workgroup handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/crowdsecurity/go-cs-bouncer v0.0.19
 	github.com/crowdsecurity/go-cs-lib v0.0.23
 	github.com/google/uuid v1.6.0
-	github.com/negasus/haproxy-spoe-go v1.0.5
+	github.com/negasus/haproxy-spoe-go v1.0.7
 	github.com/oschwald/geoip2-golang v1.9.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/negasus/haproxy-spoe-go v1.0.5 h1:iMUOg/WTdwh4qOD5VUWqXElIG6YefqdOZbTzbVXN8ZU=
-github.com/negasus/haproxy-spoe-go v1.0.5/go.mod h1:ZrBizxtx2EeLN37Jkg9w9g32a1AFCJizA8vg46PaAp4=
+github.com/negasus/haproxy-spoe-go v1.0.7 h1:OhRY0zapeHudrRqoblI9DjIolJjWI0s/TO6kT/va0ao=
+github.com/negasus/haproxy-spoe-go v1.0.7/go.mod h1:ZrBizxtx2EeLN37Jkg9w9g32a1AFCJizA8vg46PaAp4=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/oschwald/geoip2-golang v1.9.0 h1:uvD3O6fXAXs+usU+UGExshpdP13GAqp4GBrzN7IgKZc=

--- a/pkg/spoa/root.go
+++ b/pkg/spoa/root.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/netip"
 	"strings"
-	"sync"
 	"syscall"
 
 	"github.com/crowdsecurity/crowdsec-spoa/internal/geo"
@@ -34,7 +33,6 @@ type Spoa struct {
 	ListenAddr   net.Listener
 	ListenSocket net.Listener
 	Server       *agent.Agent
-	HAWaitGroup  *sync.WaitGroup
 	logger       *log.Entry
 	// Direct access to shared data (no IPC needed)
 	dataset        *dataset.DataSet
@@ -73,7 +71,6 @@ func New(config *SpoaConfig) (*Spoa, error) {
 	// No worker-specific log level; inherits from parent logger
 
 	s := &Spoa{
-		HAWaitGroup:    &sync.WaitGroup{},
 		logger:         workerLogger,
 		dataset:        config.Dataset,
 		hostManager:    config.HostManager,
@@ -162,29 +159,19 @@ func (s *Spoa) Serve(ctx context.Context) error {
 func (s *Spoa) Shutdown(ctx context.Context) error {
 	s.logger.Info("Shutting down")
 
-	doneChan := make(chan struct{})
-
-	// Close TCP listener
+	// Close TCP listener - the library now handles waiting for handlers internally
 	if s.ListenAddr != nil {
 		s.ListenAddr.Close()
 	}
 
-	// Initially  we didn't close the unix socket as we wanted to persist permissions
+	// Close Unix socket - the library now handles waiting for handlers internally
 	if s.ListenSocket != nil {
 		s.ListenSocket.Close()
 	}
 
-	go func() {
-		s.HAWaitGroup.Wait()
-		close(doneChan)
-	}()
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-doneChan:
-		return nil
-	}
+	// The library's workgroup now handles waiting for all frame handlers to complete
+	// when the listeners are closed, so we don't need to wait here
+	return nil
 }
 
 // HTTPRequestData holds parsed HTTP request data for reuse across handlers
@@ -708,9 +695,7 @@ func (s *Spoa) handleIPRequest(req *request.Request, mes *message.Message) {
 
 func handlerWrapper(s *Spoa) func(req *request.Request) {
 	return func(req *request.Request) {
-		s.HAWaitGroup.Add(1)
-		defer s.HAWaitGroup.Done()
-
+		// The library now handles workgroup tracking internally, no need for manual Add/Done
 		for _, messageName := range messageNames {
 			mes, err := req.Messages.GetByName(messageName)
 			if err != nil {


### PR DESCRIPTION
- Updated github.com/negasus/haproxy-spoe-go from v1.0.5 to v1.0.7
- Removed HAWaitGroup from Spoa struct as library now handles workgroup internally
- Removed manual Add/Done calls from handlerWrapper
- Simplified Shutdown method - library now waits for handlers when listeners are closed
- Removed unused sync import