### PR TITLE
refactor(host): remove unused runtime operations

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -166,16 +166,9 @@ func Execute() error {
 	sessionLogger := log.WithField("component", "global_sessions")
 	globalSessions.Init(sessionLogger, ctx)
 
-	g.Go(func() error {
-		HostManager.Run(ctx)
-		return nil
-	})
-
+	// Add hosts from config
 	for _, h := range config.Hosts {
-		HostManager.Chan <- host.HostOp{
-			Host: h,
-			Op:   host.OpAdd,
-		}
+		HostManager.AddHost(h)
 	}
 
 	if config.HostsDir != "" {

--- a/pkg/host/root.go
+++ b/pkg/host/root.go
@@ -1,7 +1,6 @@
 package host
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"sort"
@@ -16,19 +15,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const (
-	OpAdd    Op = "add"
-	OpRemove Op = "remove"
-	OpPatch  Op = "patch"
-)
-
-type Op string
-
-type HostOp struct {
-	Host *Host
-	Op   Op
-}
-
 type Host struct {
 	Host     string          `yaml:"host"`
 	Captcha  captcha.Captcha `yaml:"captcha"`
@@ -40,10 +26,8 @@ type Host struct {
 
 type Manager struct {
 	Hosts  []*Host
-	Chan   chan HostOp
 	Logger *log.Entry
-	cache  map[string]*Host
-	sync.RWMutex
+	cache  sync.Map // map[string]*Host - thread-safe cache for matched hosts
 }
 
 const t = `
@@ -67,59 +51,34 @@ func (h *Manager) String() string {
 func NewManager(l *log.Entry) *Manager {
 	return &Manager{
 		Hosts:  make([]*Host, 0),
-		Chan:   make(chan HostOp),
 		Logger: l,
-		cache:  make(map[string]*Host),
+		// cache is a sync.Map, zero value is ready to use
 	}
 }
 
 func (h *Manager) MatchFirstHost(toMatch string) *Host {
-	h.RLock()
-	defer h.RUnlock()
+	// Check cache first (thread-safe via sync.Map)
+	if cached, ok := h.cache.Load(toMatch); ok {
+		if host, ok := cached.(*Host); ok {
+			host.logger.WithField("requested_host", toMatch).Debug("matched host from cache")
+			return host
+		}
+	}
 
 	if len(h.Hosts) == 0 {
 		return nil
-	}
-
-	if host, ok := h.cache[toMatch]; ok {
-		host.logger.WithField("requested_host", toMatch).Debug("matched host from cache")
-		return host
 	}
 
 	for _, host := range h.Hosts {
 		matched, err := filepath.Match(host.Host, toMatch)
 		if matched && err == nil {
 			host.logger.WithField("requested_host", toMatch).Debug("matched host pattern")
-			h.cache[toMatch] = host
+			h.cache.Store(toMatch, host) // Thread-safe via sync.Map
 			return host
 		}
 	}
 	h.Logger.WithField("requested_host", toMatch).Debug("no matching host found")
 	return nil
-}
-
-func (h *Manager) Run(ctx context.Context) {
-
-	for {
-		select {
-		case instruction := <-h.Chan:
-			h.Lock()
-			switch instruction.Op {
-			case OpRemove:
-				h.cache = make(map[string]*Host)
-				h.removeHost(instruction.Host)
-			case OpAdd:
-				h.cache = make(map[string]*Host)
-				h.addHost(instruction.Host)
-				h.sort()
-			case OpPatch:
-				h.patchHost(instruction.Host)
-			}
-			h.Unlock()
-		case <-ctx.Done():
-			return
-		}
-	}
 }
 
 func (h *Manager) LoadFromDirectory(path string) error {
@@ -132,10 +91,7 @@ func (h *Manager) LoadFromDirectory(path string) error {
 		if err != nil {
 			return err
 		}
-		h.Chan <- HostOp{
-			Host: host,
-			Op:   OpAdd,
-		}
+		h.AddHost(host)
 	}
 	return nil
 }
@@ -177,24 +133,6 @@ func (h *Manager) sort() {
 	})
 }
 
-func (h *Manager) removeHost(host *Host) {
-	for i, th := range h.Hosts {
-		if th == host {
-			// Sessions persist in global manager, no cleanup needed
-			if i == len(h.Hosts)-1 {
-				h.Hosts = h.Hosts[:i]
-			} else {
-				h.Hosts = append(h.Hosts[:i], h.Hosts[i+1:]...)
-			}
-			return
-		}
-	}
-}
-
-func (h *Manager) patchHost(host *Host) {
-	//TODO
-}
-
 // createHostLogger creates a logger for a host that inherits from the base logger
 // while allowing host-specific overrides like log level
 func (h *Manager) createHostLogger(host *Host) *log.Entry {
@@ -229,7 +167,9 @@ func (h *Manager) createHostLogger(host *Host) *log.Entry {
 	return hostLogger.WithField("host", host.Host)
 }
 
-func (h *Manager) addHost(host *Host) {
+// AddHost adds a host to the manager.
+// This should only be called during initialization before concurrent access begins.
+func (h *Manager) AddHost(host *Host) {
 	// Create a logger for this host that inherits base logger values
 	host.logger = h.createHostLogger(host)
 
@@ -239,7 +179,7 @@ func (h *Manager) addHost(host *Host) {
 		"has_ban":     true, // Ban is always available
 	})
 
-	// Initialize captcha (no longer needs sessions - SPOA handles that)
+	// Initialize captcha
 	if err := host.Captcha.Init(host.logger); err != nil {
 		host.logger.Error(err)
 	}
@@ -249,5 +189,10 @@ func (h *Manager) addHost(host *Host) {
 	if err := host.AppSec.Init(host.logger); err != nil {
 		host.logger.Error(err)
 	}
+
+	// Add to Hosts slice
 	h.Hosts = append(h.Hosts, host)
+
+	// Sort hosts for priority matching
+	h.sort()
 }


### PR DESCRIPTION
Remove the Run goroutine, channel-based operations, and associated types that are no longer used. Hosts are now added synchronously at startup.

Changes:
- Remove Manager.Run(), Manager.Chan
- Remove HostOp, Op types and constants
- Remove removeHost() and patchHost() dead code
- Remove sync.RWMutex (not needed - hosts only added at startup)
- Use sync.Map for thread-safe cache during concurrent MatchFirstHost
- Make AddHost public for direct synchronous calls
- Update cmd/root.go to use AddHost directly

This simplifies the architecture by removing ~80 lines of unnecessary complexity while maintaining thread-safe cache access.