### PR TITLE
fix(prometheus): add graceful shutdown for server

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -123,16 +123,36 @@ func Execute() error {
 	prometheus.MustRegister(csbouncer.TotalLAPICalls, csbouncer.TotalLAPIError, metrics.TotalActiveDecisions, metrics.TotalBlockedRequests, metrics.TotalProcessedRequests)
 
 	if config.PrometheusConfig.Enabled {
-		go func() {
-			http.Handle("/metrics", promhttp.Handler())
+		promMux := http.NewServeMux()
+		promMux.Handle("/metrics", promhttp.Handler())
 
-			listenOn := net.JoinHostPort(
-				config.PrometheusConfig.ListenAddress,
-				config.PrometheusConfig.ListenPort,
-			)
+		listenOn := net.JoinHostPort(
+			config.PrometheusConfig.ListenAddress,
+			config.PrometheusConfig.ListenPort,
+		)
+
+		promServer := &http.Server{
+			Addr:    listenOn,
+			Handler: promMux,
+		}
+
+		g.Go(func() error {
 			log.Infof("Serving metrics at %s", listenOn+"/metrics")
-			log.Error(http.ListenAndServe(listenOn, nil))
-		}()
+			if err := promServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				return fmt.Errorf("prometheus server error: %w", err)
+			}
+			return nil
+		})
+
+		g.Go(func() error {
+			<-ctx.Done()
+			log.Info("Shutting down prometheus server...")
+			// Use background context since parent ctx is already canceled
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			//nolint:contextcheck // parent ctx is canceled, need fresh context for shutdown
+			return promServer.Shutdown(shutdownCtx)
+		})
 	}
 
 	// pprof debug endpoint for runtime profiling (memory, CPU, goroutines)


### PR DESCRIPTION
Refactor Prometheus server to match pprof pattern:
- Use dedicated http.ServeMux instead of default mux
- Manage server lifecycle with errgroup
- Add graceful shutdown handler with 5s timeout
- Proper error propagation instead of fire-and-forget goroutine

This ensures the Prometheus server shuts down cleanly on SIGTERM/SIGINT and errors are properly tracked by the errgroup.