### PR TITLE
feat: add default hosts directory at /etc/crowdsec/bouncers/spoa-host.d

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ COPY . .
 RUN make build DOCKER_BUILD=1
 
 # Create directory structure for scratch image (with .keep files so COPY works)
-RUN mkdir -p /run/crowdsec-spoa /var/log/crowdsec-spoa && \
-    touch /run/crowdsec-spoa/.keep /var/log/crowdsec-spoa/.keep
+RUN mkdir -p /run/crowdsec-spoa /var/log/crowdsec-spoa /etc/crowdsec/bouncers/spoa-host.d && \
+    touch /run/crowdsec-spoa/.keep /var/log/crowdsec-spoa/.keep /etc/crowdsec/bouncers/spoa-host.d/.keep
 
 # Final minimal image
 FROM scratch
@@ -23,6 +23,7 @@ ENV LOG_MODE=stdout \
     UPDATE_FREQUENCY=10s \
     INSECURE_SKIP_VERIFY=false \
     LISTEN_TCP=0.0.0.0:9000 \
+    HOSTS_DIR=/etc/crowdsec/bouncers/spoa-host.d \
     PROMETHEUS_ENABLED=true \
     PROMETHEUS_ADDR=0.0.0.0 \
     PROMETHEUS_PORT=6060
@@ -46,9 +47,13 @@ COPY --from=build /go/src/cs-spoa-bouncer/templates/ /var/lib/crowdsec-haproxy-s
 COPY --from=build /run/crowdsec-spoa/ /run/crowdsec-spoa/
 COPY --from=build /var/log/crowdsec-spoa/ /var/log/crowdsec-spoa/
 
+# Copy hosts configuration directory
+COPY --from=build /etc/crowdsec/bouncers/spoa-host.d/ /etc/crowdsec/bouncers/spoa-host.d/
+
 # Declare volumes for customizable content
 VOLUME /usr/lib/crowdsec-haproxy-spoa-bouncer/lua/
 VOLUME /var/lib/crowdsec-haproxy-spoa-bouncer/html/
+VOLUME /etc/crowdsec/bouncers/spoa-host.d/
 
 EXPOSE 9000 6060
 

--- a/config/crowdsec-spoa-bouncer.docker.yaml
+++ b/config/crowdsec-spoa-bouncer.docker.yaml
@@ -25,6 +25,10 @@ listen_tcp: ${LISTEN_TCP}
 #appsec_url: ${APPSEC_URL}
 #appsec_timeout: ${APPSEC_TIMEOUT}
 
+## Host configuration directory
+## Mount your per-host config files here (*.yaml)
+hosts_dir: ${HOSTS_DIR}
+
 ## Prometheus metrics endpoint
 prometheus:
   enabled: ${PROMETHEUS_ENABLED}

--- a/config/crowdsec-spoa-bouncer.service
+++ b/config/crowdsec-spoa-bouncer.service
@@ -24,6 +24,8 @@ RuntimeDirectoryMode=2750
 RuntimeDirectoryPreserve=yes
 LogsDirectory=crowdsec-spoa
 LogsDirectoryMode=0750
+# Allow read access to hosts configuration directory
+ReadOnlyPaths=/etc/crowdsec/bouncers/spoa-host.d
 
 [Install]
 WantedBy=multi-user.target

--- a/config/crowdsec-spoa-bouncer.yaml
+++ b/config/crowdsec-spoa-bouncer.yaml
@@ -25,6 +25,11 @@ prometheus:
   listen_addr: 127.0.0.1
   listen_port: 60601
 
+## Host configuration directory
+## Place per-host YAML config files here (*.yaml)
+## See documentation for host configuration format
+hosts_dir: /etc/crowdsec/bouncers/spoa-host.d
+
 ## pprof debug endpoint for runtime profiling
 ## WARNING: Only enable for debugging, exposes internal runtime data
 ## Endpoints: /debug/pprof/heap, /debug/pprof/profile, /debug/pprof/goroutine, etc.

--- a/debian/postinst
+++ b/debian/postinst
@@ -30,6 +30,13 @@ if [ -f "$CONFIG" ]; then
     chgrp crowdsec-spoa "$CONFIG" 2>/dev/null || true
 fi
 
+# Set hosts directory permissions (read-only for crowdsec-spoa user)
+HOSTS_DIR="/etc/crowdsec/bouncers/spoa-host.d"
+if [ -d "$HOSTS_DIR" ]; then
+    chown root:crowdsec-spoa "$HOSTS_DIR" 2>/dev/null || true
+    chmod 750 "$HOSTS_DIR" 2>/dev/null || true
+fi
+
 if [ -d "/etc/haproxy" ]; then
     cp /usr/share/doc/crowdsec-haproxy-spoa-bouncer/examples/crowdsec.cfg /etc/haproxy/crowdsec.cfg
 fi

--- a/debian/rules
+++ b/debian/rules
@@ -30,7 +30,8 @@ override_dh_auto_install:
 	install -m 644 -D "lua/template.lua" "debian/$$PKG/usr/lib/$$PKG/lua/template.lua"; \
 	mkdir -p "debian/$$PKG/var/lib/$$PKG/html"; \
 	install -m 644 -D "templates/ban.html" "debian/$$PKG/var/lib/$$PKG/html/ban.html"; \
-	install -m 644 -D "templates/captcha.html" "debian/$$PKG/var/lib/$$PKG/html/captcha.html"
+	install -m 644 -D "templates/captcha.html" "debian/$$PKG/var/lib/$$PKG/html/captcha.html"; \
+	mkdir -p "debian/$$PKG/etc/crowdsec/bouncers/spoa-host.d"
 
 execute_after_dh_fixperms:
 	@BOUNCER=crowdsec-spoa-bouncer; \

--- a/rpm/SPECS/crowdsec-haproxy-spoa-bouncer.spec
+++ b/rpm/SPECS/crowdsec-haproxy-spoa-bouncer.spec
@@ -35,6 +35,7 @@ rm -rf %{buildroot}
 mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_libdir}/%{name}/lua
 mkdir -p %{buildroot}%{_localstatedir}/lib/%{name}/html
+mkdir -p %{buildroot}/etc/crowdsec/bouncers/spoa-host.d
 mkdir -p %{buildroot}%{_docdir}/%{name}/examples
 install -m 755 -D %{binary_name} %{buildroot}%{_bindir}/%{binary_name}
 install -m 640 -D config/%{binary_name}.yaml %{buildroot}/etc/crowdsec/bouncers/%{binary_name}.yaml
@@ -65,6 +66,7 @@ rm -rf %{buildroot}
 /usr/lib/%{name}/lua/template.lua
 %{_localstatedir}/lib/%{name}/html/ban.html
 %{_localstatedir}/lib/%{name}/html/captcha.html
+%dir /etc/crowdsec/bouncers/spoa-host.d
 
 %post
 # Reload systemd units
@@ -103,6 +105,13 @@ fi
 # Set config file group ownership (matches Debian postinst)
 if [ -f "$CONFIG" ]; then
     chgrp crowdsec-spoa "$CONFIG" 2>/dev/null || true
+fi
+
+# Set hosts directory permissions (read-only for crowdsec-spoa user)
+HOSTS_DIR="/etc/crowdsec/bouncers/spoa-host.d"
+if [ -d "$HOSTS_DIR" ]; then
+    chown root:crowdsec-spoa "$HOSTS_DIR" 2>/dev/null || true
+    chmod 750 "$HOSTS_DIR" 2>/dev/null || true
 fi
 
 if [ -d "/etc/haproxy" ]; then


### PR DESCRIPTION
Configure hosts_dir as default location for per-host YAML configs. Package installations create the directory with read-only permissions for the crowdsec-spoa user (root:crowdsec-spoa, mode 750).