### PR TITLE
install: improve user creation process

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -19,7 +19,7 @@ systemctl --quiet is-enabled "$SERVICE" || systemctl unmask "$SERVICE" && system
 set_local_lapi_url 'CROWDSEC_LAPI_URL'
 
 if ! getent passwd crowdsec-spoa >/dev/null; then
-    adduser crowdsec-spoa --system --group --comment "crowdsec haproxy spoa bouncer"
+    adduser --system --group --no-create-home --shell /sbin/nologin crowdsec-spoa
 fi
 
 # Set config file group ownership and permissions

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,6 +29,12 @@ gen_config_file() {
     (umask 177 && API_KEY="$API_KEY" envsubst '$API_KEY' <"./config/$CONFIG_FILE" > "$CONFIG")
 }
 
+create_user() {
+    if ! getent passwd crowdsec-spoa >/dev/null; then
+        adduser --system --group --no-create-home --shell /sbin/nologin crowdsec-spoa
+    fi
+}
+
 install_bouncer() {
     if [ ! -f "$BIN_PATH" ]; then
         msg err "$BIN_PATH not found, exiting."
@@ -44,6 +50,7 @@ install_bouncer() {
     # shellcheck disable=SC2016
     CFG=${CONFIG_DIR} BIN=${BIN_PATH_INSTALLED} envsubst '$CFG $BIN' <"./config/$SERVICE" >"$SYSTEMD_PATH_FILE"
     systemctl daemon-reload
+    create_user
     gen_apikey
     gen_config_file
 }


### PR DESCRIPTION
`--comment` was only introduced in Ubuntu 23.04, which breaks the installation on older versions.

As well, make sure to create the user when manually installing the bouncer with the install script.