### PR TITLE
Fix XSS vulnerability: validate URL scheme and HTML-escape contact_us…

### DIFF
--- a/internal/remediation/ban/root.go
+++ b/internal/remediation/ban/root.go
@@ -1,6 +1,8 @@
 package ban
 
 import (
+	"net/url"
+
 	"github.com/dropmorepackets/haproxy-go/pkg/encoding"
 	log "github.com/sirupsen/logrus"
 )
@@ -20,5 +22,12 @@ func (b *Ban) InitLogger(logger *log.Entry) {
 }
 
 func (b *Ban) InjectKeyValues(writer *encoding.ActionWriter) {
-	_ = writer.SetString(encoding.VarScopeTransaction, "contact_us_url", b.ContactUsURL)
+	contactURL := b.ContactUsURL
+	if contactURL != "" {
+		u, err := url.Parse(contactURL)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https" && u.Scheme != "mailto") {
+			contactURL = ""
+		}
+	}
+	_ = writer.SetString(encoding.VarScopeTransaction, "contact_us_url", contactURL)
 }

--- a/lua/crowdsec.lua
+++ b/lua/crowdsec.lua
@@ -53,6 +53,10 @@ end
 
 local runtime = {}
 
+local function html_escape(s)
+    return s:gsub('&', '&amp;'):gsub('<', '&lt;'):gsub('>', '&gt;'):gsub('"', '&quot;')
+end
+
 -- Loads the configuration
 local function init()
     BAN_TEMPLATE_PATH = os.getenv("CROWDSEC_BAN_TEMPLATE_PATH")
@@ -133,7 +137,7 @@ function runtime.Handle(txn)
 
     if remediation == "ban" then
         reply:set_body(runtime.ban.render({
-            ["contact_us_url"]=get_txn_var(txn, "crowdsec.contact_us_url"),
+            ["contact_us_url"]=html_escape(get_txn_var(txn, "crowdsec.contact_us_url")),
         }))
     end
 

--- a/templates/ban-with-contact.html
+++ b/templates/ban-with-contact.html
@@ -17,7 +17,7 @@
             </svg>
             <h1 class="text-xl md:text-2xl lg:text-3xl xl:text-4xl"> CrowdSec Access Forbidden</h1>
             <p class="lg:text-xl md:text-lg"> You are unable to visit the website.</p>
-                        <a href="%[var(txn.crowdsec.contact_us_url),regsub(&,\&amp;,g)]" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+                        <a href="%[var(txn.crowdsec.contact_us_url),html]" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
               Contact Us
             </a>
           </div>


### PR DESCRIPTION
…_url

- Validate contact_us_url scheme (only http/https/mailto allowed) in Go before setting the HAProxy variable, preventing javascript: XSS
- Use HAProxy html converter in ban-with-contact.html for proper HTML-escaping (replaces incomplete regsub that only handled ampersands)
- Add html_escape() helper in crowdsec.lua and apply it to contact_us_url before passing it to the Lua template renderer