### PR TITLE
Fix broken 'html' HAProxy converter in ban-with-contact.html

### DIFF
--- a/internal/remediation/ban/root.go
+++ b/internal/remediation/ban/root.go
@@ -1,6 +1,7 @@
 package ban
 
 import (
+	"html"
 	"net/url"
 
 	"github.com/dropmorepackets/haproxy-go/pkg/encoding"
@@ -29,5 +30,5 @@ func (b *Ban) InjectKeyValues(writer *encoding.ActionWriter) {
 			contactURL = ""
 		}
 	}
-	_ = writer.SetString(encoding.VarScopeTransaction, "contact_us_url", contactURL)
+	_ = writer.SetString(encoding.VarScopeTransaction, "contact_us_url", html.EscapeString(contactURL))
 }

--- a/lua/crowdsec.lua
+++ b/lua/crowdsec.lua
@@ -53,10 +53,6 @@ end
 
 local runtime = {}
 
-local function html_escape(s)
-    return s:gsub('&', '&amp;'):gsub('<', '&lt;'):gsub('>', '&gt;'):gsub('"', '&quot;')
-end
-
 -- Loads the configuration
 local function init()
     BAN_TEMPLATE_PATH = os.getenv("CROWDSEC_BAN_TEMPLATE_PATH")
@@ -137,7 +133,7 @@ function runtime.Handle(txn)
 
     if remediation == "ban" then
         reply:set_body(runtime.ban.render({
-            ["contact_us_url"]=html_escape(get_txn_var(txn, "crowdsec.contact_us_url")),
+            ["contact_us_url"]=get_txn_var(txn, "crowdsec.contact_us_url"),
         }))
     end
 

--- a/templates/ban-with-contact.html
+++ b/templates/ban-with-contact.html
@@ -17,7 +17,7 @@
             </svg>
             <h1 class="text-xl md:text-2xl lg:text-3xl xl:text-4xl"> CrowdSec Access Forbidden</h1>
             <p class="lg:text-xl md:text-lg"> You are unable to visit the website.</p>
-                        <a href="%[var(txn.crowdsec.contact_us_url),html]" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+                        <a href="%[var(txn.crowdsec.contact_us_url)]" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
               Contact Us
             </a>
           </div>


### PR DESCRIPTION
## Summary
- PR #166 tried to HTML-escape `contact_us_url` in the native HAProxy template using a `,html` converter, but HAProxy has no such converter. Verified against the actual `haproxy:2.9.7-alpine` image used by this repo's docker-compose: `haproxy -c` fails with `unknown converter 'html'`, so any deployment enabling `ban-with-contact.html` (via the `lf-file` directive in `haproxy.cfg`) fails to start.
- Moves escaping to the single point where `contact_us_url` is produced — `internal/remediation/ban/root.go`, via stdlib `html.EscapeString` — after the existing scheme allowlist check, instead of duplicating escaping logic in both the Lua template renderer and the HAProxy config.
- Removes the now-redundant hand-rolled `html_escape()` in `lua/crowdsec.lua`; the Lua ban template consumes the already-escaped value.
- Reverts `templates/ban-with-contact.html` to a plain `%[var(txn.crowdsec.contact_us_url)]` (no converter needed).

## Test plan
- [x] `go build ./...` and `go vet ./internal/remediation/ban/...` pass
- [x] Re-validated `templates/ban-with-contact.html` against real `haproxy:2.9.7-alpine` via `haproxy -c` — now exits 0 (previously failed with `unknown converter 'html'`)
- [ ] Manual smoke test of the ban-with-contact page in a running stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)